### PR TITLE
Update Lec1.agda and Exe1.agda

### DIFF
--- a/Exe1.agda
+++ b/Exe1.agda
@@ -75,10 +75,11 @@ record Applicative (F : Set -> Set) : Set1 where
   applicativeEndoFunctor = record { map = _<*>_ o pure }
 open Applicative {{...}} public
 
-applicativeVec  : forall {n} -> Applicative \ X -> Vec X n
-applicativeVec  = record { pure = vec; _<*>_ = vapp }
-endoFunctorVec  : forall {n} -> EndoFunctor \ X -> Vec X n
-endoFunctorVec  = applicativeEndoFunctor
+instance
+  applicativeVec  : forall {n} -> Applicative \ X -> Vec X n
+  applicativeVec  = record { pure = vec; _<*>_ = vapp }
+  endoFunctorVec  : forall {n} -> EndoFunctor \ X -> Vec X n
+  endoFunctorVec  = applicativeEndoFunctor
 
 applicativeFun : forall {S} -> Applicative \ X -> S -> X
 applicativeFun = record

--- a/Lec1.agda
+++ b/Lec1.agda
@@ -82,10 +82,12 @@ record Applicative (F : Set -> Set) : Set1 where
   applicativeEndoFunctor = record { map = _<*>_ o pure }
 open Applicative {{...}} public
 
-applicativeVec  : forall {n} -> Applicative \ X -> Vec X n
-applicativeVec  = record { pure = vec; _<*>_ = vapp }
-endoFunctorVec  : forall {n} -> EndoFunctor \ X -> Vec X n
-endoFunctorVec  = applicativeEndoFunctor
+instance
+ applicativeVec  : forall {n} -> Applicative \ X -> Vec X n
+ applicativeVec  = record { pure = vec; _<*>_ = vapp }
+
+ endoFunctorVec  : forall {n} -> EndoFunctor \ X -> Vec X n
+ endoFunctorVec  = applicativeEndoFunctor
 
 applicativeFun : forall {S} -> Applicative \ X -> S -> X
 applicativeFun = record


### PR DESCRIPTION
The current function `endoFunctorVec`
```agda
endoFunctorVec : ∀ {n} → EndoFunctor λ X → Vec X n
endoFunctorVec = applicativeEndoFunctor
```
generates the following error 
Error : 
```agda
No instance of type Applicative (λ X → Vec X n) was found in scope.
when checking that the expression applicativeEndoFunctor has type
EndoFunctor (λ X → Vec X n)
````
and it was due to the fact the it was looking for a instance of `Applicative` that satisfies the type `Applicative (λ X → Vec X n)`  which is `applicativeVec` but since that is not specified by the `instance` keyword this particular function fails to generate the instance of `EndoFunctor`

This PR fixes that.